### PR TITLE
Add registration link in articles

### DIFF
--- a/pages/articles/[id].js
+++ b/pages/articles/[id].js
@@ -1,10 +1,25 @@
 import { useRouter } from "next/router";
 import styles from "../../styles/Article.module.css";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Text, Paper, Title, Image } from "@mantine/core";
 
 function Article() {
   const router = useRouter();
+
+  const [registrationLink, setRegistrationLink] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const hostname = window.location.hostname;
+      const subdomain = hostname.split(".")[0];
+      const redirectTo = window.location.href;
+      const link = `https://register.axate.io/?pub=${subdomain}&redirectTo=${encodeURIComponent(
+        redirectTo,
+      )}`;
+      setRegistrationLink(link);
+    }
+  }, []);
 
   const imageURL = "/bg.jpg";
 
@@ -22,6 +37,9 @@ function Article() {
           <Title order={3} size="h1">
             Welcome to Post #{router.query.id}!
           </Title>
+          {registrationLink && (
+            <a href={registrationLink}>Go to new registration</a>
+          )}
           <Image
             className="myImage"
             src="https://images.unsplash.com/photo-1712839398257-8f7ee9127998?ixlib=rb-	1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=200&h=120"


### PR DESCRIPTION
## Summary
- compute registration link from subdomain and current URL
- add 'Go to new registration' link near article titles

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fae2c23f08323800714d34c6976af