### PR TITLE
Add security headers and sanitize script loading

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,42 @@
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' https://wallet.axate.io https://wallet-staging.axate.io;
+  child-src 'none';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' https://source.unsplash.com https://images.unsplash.com data:;
+`;
+
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: ContentSecurityPolicy.replace(/\n/g, ""),
+  },
+  {
+    key: "Referrer-Policy",
+    value: "same-origin",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-DNS-Prefetch-Control",
+    value: "on",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains; preload",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
 module.exports = {
   images: {
     remotePatterns: [
@@ -10,5 +49,13 @@ module.exports = {
   },
   experimental: {
     optimizePackageImports: ["@mantine/core", "@mantine/hooks"],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
 };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,7 +8,7 @@ export default function MyApp({ Component, pageProps }) {
     /** Put your mantine theme override here */
   });
 
-  const [enviroment, setEnviroment] = useState("");
+  const [enviroment, setEnviroment] = useState("staging");
   const [localStorageReady, setLocalStorageReady] = useState(false);
 
   let axateScriptStaging = "https://wallet-staging.axate.io/bundle.js";
@@ -17,13 +17,13 @@ export default function MyApp({ Component, pageProps }) {
 
   useEffect(() => {
     const storedValue = localStorage.getItem("selectedEnviroment");
-    if (storedValue) {
-      setEnviroment(storedValue);
+    if (storedValue === "live") {
+      setEnviroment("live");
+    } else {
+      setEnviroment("staging");
     }
     setLocalStorageReady(true);
   }, []);
-
-  console.log(enviroment);
 
   if (!localStorageReady) {
     return <div>Loading Branch Master...</div>;
@@ -34,6 +34,7 @@ export default function MyApp({ Component, pageProps }) {
       <MantineProvider theme={theme}>
         <Script
           src={enviroment === "live" ? axateScriptLive : axateScriptStaging}
+          crossOrigin="anonymous"
         />
         <Component {...pageProps} />
       </MantineProvider>


### PR DESCRIPTION
## Summary
- set strict content security policy and other security headers
- sanitize local storage environment option
- add anonymous cross-origin attribute on Axate script

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fdaa1611883239136f3d9e38d3874