### PR TITLE
Improve homepage grid layout

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -122,21 +122,18 @@ export default function Home() {
             // article, so start cycling from the second gradient.
             const gradientNum = (index % (gradients.length - 1)) + 1;
             const articleNum = index + 2;
+            const isLarge = index % 7 === 0;
             return (
               <Link
                 href={`/articles/${articleNum}`}
-                className={styles.card}
+                className={`${styles.card} ${isLarge ? styles.cardLarge : ""}`}
                 key={articleNum}
               >
                 <div
-                  className={styles.cardImage}
-                  style={{
-                    width: "100%",
-                    height: "160px",
-                    borderRadius: "12px",
-                    marginBottom: "1rem",
-                    background: gradients[gradientNum],
-                  }}
+                  className={`${styles.cardImage} ${
+                    isLarge ? styles.cardLargeImage : ""
+                  }`}
+                  style={{ background: gradients[gradientNum] }}
                 />
                 <h3>Article #{articleNum}</h3>
                 <p>Find in-depth here...</p>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -70,6 +70,16 @@
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 1.5rem;
   margin-top: 2rem;
+  grid-auto-flow: dense;
+}
+
+.cardLarge {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+.cardLargeImage {
+  height: 340px;
 }
 
 .card {
@@ -90,6 +100,7 @@
 .cardImage {
   width: 100%;
   height: 160px;
+  margin-bottom: 1rem;
   object-fit: cover;
 }
 
@@ -117,6 +128,14 @@
     grid-template-columns: 1fr;
   }
   .cardImage {
+    height: 200px;
+    background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  }
+  .cardLarge {
+    grid-column: span 1;
+    grid-row: span 1;
+  }
+  .cardLargeImage {
     height: 200px;
     background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
   }


### PR DESCRIPTION
## Summary
- make the homepage grid irregular so certain cards span more space
- adjust small screen layout

## Testing
- `npx prettier --write "**/*.{js,jsx,ts,tsx,css,html,json,md}"`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68800870a1448323ad62375f7b2f4f3c