### PR TITLE
Apply emerald background overlay for light version

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import Script from "next/script";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import { createTheme, MantineProvider } from "@mantine/core";
+import "../styles/globals.css";
 
 export default function MyApp({ Component, pageProps }) {
   const theme = createTheme({
@@ -32,10 +33,12 @@ export default function MyApp({ Component, pageProps }) {
   return (
     <>
       <MantineProvider theme={theme}>
-        <Script
-          src={enviroment === "live" ? axateScriptLive : axateScriptStaging}
-        />
-        <Component {...pageProps} />
+        <div className="light-wrapper">
+          <Script
+            src={enviroment === "live" ? axateScriptLive : axateScriptStaging}
+          />
+          <Component {...pageProps} />
+        </div>
       </MantineProvider>
     </>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,3 +38,23 @@ button {
 img {
   height: 200px;
 }
+
+.light-wrapper {
+  min-height: 100vh;
+  width: 100%;
+  background-color: #fff;
+  position: relative;
+}
+
+.light-wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-image: radial-gradient(
+    125% 125% at 50% 90%,
+    #ffffff 40%,
+    #10b981 100%
+  );
+  background-size: 100% 100%;
+}


### PR DESCRIPTION
## Summary
- import global styles in `_app.js`
- wrap app content in a `light-wrapper` div
- define `.light-wrapper` styles to render emerald glow radial background

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880ab9b90b08323919385cad8930283