### PR TITLE
Scope global styles to avoid impacting external widgets

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import Script from "next/script";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import { createTheme, MantineProvider } from "@mantine/core";
+import "../styles/globals.css";
 
 export default function MyApp({ Component, pageProps }) {
   const theme = createTheme({
@@ -30,13 +31,13 @@ export default function MyApp({ Component, pageProps }) {
   }
 
   return (
-    <>
+    <div className="app-container">
       <MantineProvider theme={theme}>
         <Script
           src={enviroment === "live" ? axateScriptLive : axateScriptStaging}
         />
         <Component {...pageProps} />
       </MantineProvider>
-    </>
+    </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,37 +4,37 @@ body {
   margin: 0;
 }
 
-a {
+.app-container a {
   color: inherit;
   text-decoration: none;
 }
 
-* {
+.app-container * {
   box-sizing: border-box;
 }
 
-img {
+.app-container img {
   max-width: 100%;
   height: auto;
 }
 
-h1,
-h2,
-p,
-ul {
+.app-container h1,
+.app-container h2,
+.app-container p,
+.app-container ul {
   margin: 0;
 }
 
-ul {
+.app-container ul {
   padding: 0;
   list-style: none;
 }
 
-button {
+.app-container button {
   padding: 0.5rem 1rem;
   font-weight: bold;
 }
 
-img {
+.app-container img {
   height: 200px;
 }


### PR DESCRIPTION
## Summary
- import global stylesheet and wrap app in `.app-container`
- scope global selectors under `.app-container` so external ads/widgets are unaffected

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a30c45685483239842bd4ec08a0ffc