### PR TITLE
Specify Node.js 22 runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
         "postcss": "^8.4.35",
         "postcss-preset-mantine": "^1.13.0",
         "postcss-simple-vars": "^7.0.1"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- require Node.js 22.x via the package.json engines field
- propagate the Node 22.x engine requirement in the lockfile metadata

## Testing
- npm install
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cbf6ce022483239457eac96ab77b85