### PR TITLE
Add well-known passkey endpoint

### DIFF
--- a/public/.well-known/passkey
+++ b/public/.well-known/passkey
@@ -1,0 +1,1 @@
+I don't have that function


### PR DESCRIPTION
## Summary
- add a static `/.well-known/passkey` endpoint that returns a placeholder message indicating the functionality is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef0b7ce448323a4a6ac0957a3108e